### PR TITLE
Fixed Warning: ViewPagerAndroid has been extracted from react-native core 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ the animations behind this work, check out the Rebound section of the
 ## Add it to your project
 
 1. Run `npm install react-native-scrollable-tab-view --save`
-2. `var ScrollableTabView = require('react-native-scrollable-tab-view');`
+2. Run `react-native link @react-native-community/viewpager`
+3. `var ScrollableTabView = require('react-native-scrollable-tab-view');`
 
 ## Demo
 <a href="https://appetize.io/embed/6qfv7eydjtm34mhn6qwj2nt3xm?embed=true&screenOnly=false&xdocMsg=true&debug=true&scale=100&deviceColor=black&orientation=portrait&device=iphone6s&osVersion=9.3&deviceId=RGV2aWNlOjU2Y2FjNTExZWQwOTM2MTEwMGRhYTNlNg&platform=ios&width=375&height=668&phoneWidth=416&phoneHeight=870&screenOffsetLeft=21&screenOffsetTop=100&params=%7B%7D" target="_blank"><strong>Run this example</strong></a>

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ const {
   ScrollView,
   Platform,
   StyleSheet,
-  ViewPagerAndroid,
   InteractionManager,
 } = ReactNative;
+const ViewPagerAndroid = require('@react-native-community/viewpager');
 const TimerMixin = require('react-timer-mixin');
 
 const SceneComponent = require('./SceneComponent');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/brentvatne/react-native-scrollable-tab-view#readme",
   "dependencies": {
+    "@react-native-community/viewpager": "^1.1.7",
     "react-timer-mixin": "^0.13.3",
     "prop-types": "^15.6.0",
     "create-react-class": "^15.6.2"


### PR DESCRIPTION
ExceptionsManager.js:82 Warning: ViewPagerAndroid has been extracted from react-native core and will be removed in a future release. It can now be installed and imported from '@react-native-community/viewpager' instead of 'react-native'. See https://github.com/react-native-community/react-native-viewpager